### PR TITLE
Add OpenAI integration management hub

### DIFF
--- a/assets/js/integrations.js
+++ b/assets/js/integrations.js
@@ -1,0 +1,416 @@
+const notification = {
+    info(message) {
+        if (typeof window !== 'undefined' && typeof window.showNotification === 'function') {
+            window.showNotification(message, 'info');
+        } else {
+            console.log('[INFO]', message);
+        }
+    },
+    success(message) {
+        if (typeof window !== 'undefined' && typeof window.showNotification === 'function') {
+            window.showNotification(message, 'success');
+        } else {
+            console.log('[SUCCESS]', message);
+        }
+    },
+    error(message) {
+        if (typeof window !== 'undefined' && typeof window.showNotification === 'function') {
+            window.showNotification(message, 'error');
+        } else {
+            console.error('[ERROR]', message);
+        }
+    },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    const statusBadge = document.getElementById('openai-status-badge');
+    const statusText = document.getElementById('openai-status-text');
+    const cacheDetails = document.getElementById('openai-cache-details');
+    const modelsList = document.getElementById('openai-model-list');
+    const loadModelsBtn = document.getElementById('load-openai-models');
+    const connectorsGrid = document.getElementById('integration-grid');
+    const catalogEmptyState = document.getElementById('integration-empty-state');
+    const connectorForm = document.getElementById('connector-suggestion-form');
+    const connectorResults = document.getElementById('connector-suggestions');
+    const connectorSummary = document.getElementById('connector-summary');
+
+    async function bootstrap() {
+        await refreshCatalog();
+        attachTestButtons();
+    }
+
+    async function refreshCatalog() {
+        try {
+            const response = await fetch('/api/integrations');
+            if (!response.ok) {
+                throw new Error(`Failed to load integrations (${response.status})`);
+            }
+
+            const data = await response.json();
+            const connectors = Array.isArray(data?.connectors) ? data.connectors : [];
+            renderConnectors(connectors);
+            updateStatusMeta(data?.meta?.openai || {});
+        } catch (error) {
+            console.error('Failed to refresh integration catalog', error);
+            updateStatusMeta({ configured: false });
+            showEmptyState(`Unable to load integration catalog: ${error.message}`);
+        }
+    }
+
+    function renderConnectors(connectors = []) {
+        if (!connectorsGrid) {
+            return;
+        }
+
+        connectorsGrid.innerHTML = '';
+
+        if (!connectors.length) {
+            showEmptyState('No integrations available yet. Configure OPEN_API_KEY to unlock OpenAI connectors.');
+            return;
+        }
+
+        connectors.forEach((connector) => {
+            const card = document.createElement('article');
+            card.className = 'bg-white rounded-2xl shadow-lg border border-slate-200 p-6 flex flex-col gap-4';
+            card.setAttribute('data-connector-id', connector.id);
+
+            const header = document.createElement('div');
+            header.className = 'flex items-start justify-between gap-4';
+
+            const titleWrapper = document.createElement('div');
+            titleWrapper.className = 'flex flex-col';
+
+            const title = document.createElement('h3');
+            title.className = 'text-xl font-semibold text-slate-900';
+            title.textContent = connector.name;
+
+            const subtitle = document.createElement('p');
+            subtitle.className = 'text-sm text-slate-500';
+            subtitle.textContent = connector.description;
+
+            titleWrapper.appendChild(title);
+            titleWrapper.appendChild(subtitle);
+
+            const badge = document.createElement('span');
+            badge.className = getStatusBadgeClasses(connector.status);
+            badge.textContent = connector.status === 'connected' ? 'Connected' : 'Needs setup';
+            badge.setAttribute('aria-label', connector.statusMessage || 'Connector status');
+
+            header.appendChild(titleWrapper);
+            header.appendChild(badge);
+
+            const featureList = document.createElement('ul');
+            featureList.className = 'list-disc list-inside text-sm text-slate-600 space-y-1';
+            (connector.features || []).forEach((feature) => {
+                const li = document.createElement('li');
+                li.textContent = feature;
+                featureList.appendChild(li);
+            });
+
+            const footer = document.createElement('div');
+            footer.className = 'flex flex-wrap gap-2 items-center';
+
+            const statusMessage = document.createElement('p');
+            statusMessage.className = 'text-xs text-slate-500 flex-1';
+            statusMessage.textContent = connector.statusMessage || '';
+
+            footer.appendChild(statusMessage);
+
+            if (connector.documentationUrl) {
+                const docLink = document.createElement('a');
+                docLink.href = connector.documentationUrl;
+                docLink.target = '_blank';
+                docLink.rel = 'noopener noreferrer';
+                docLink.className = 'inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-700';
+                docLink.innerHTML = '<span>Docs</span><i data-feather="external-link" class="w-3 h-3"></i>';
+                footer.appendChild(docLink);
+            }
+
+            if (connector.actions?.testable) {
+                const testButton = document.createElement('button');
+                testButton.type = 'button';
+                testButton.dataset.integrationTest = connector.provider;
+                testButton.className = 'px-3 py-2 text-xs font-semibold rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400';
+                testButton.textContent = 'Run health check';
+                footer.appendChild(testButton);
+            }
+
+            card.appendChild(header);
+            card.appendChild(featureList);
+            card.appendChild(footer);
+
+            connectorsGrid.appendChild(card);
+        });
+
+        if (typeof feather !== 'undefined') {
+            feather.replace();
+        }
+
+        if (catalogEmptyState) {
+            catalogEmptyState.classList.add('hidden');
+        }
+    }
+
+    function showEmptyState(message) {
+        if (catalogEmptyState) {
+            catalogEmptyState.classList.remove('hidden');
+            catalogEmptyState.textContent = message;
+        }
+        if (connectorsGrid) {
+            connectorsGrid.innerHTML = '';
+        }
+    }
+
+    function getStatusBadgeClasses(status) {
+        const base = 'inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold';
+        if (status === 'connected') {
+            return `${base} bg-emerald-100 text-emerald-700`;
+        }
+        if (status === 'requires_configuration') {
+            return `${base} bg-amber-100 text-amber-700`;
+        }
+        return `${base} bg-slate-200 text-slate-600`;
+    }
+
+    function updateStatusMeta(meta) {
+        if (statusBadge) {
+            statusBadge.className = meta.configured
+                ? 'inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-100 text-emerald-700 text-sm font-semibold'
+                : 'inline-flex items-center gap-2 px-3 py-1 rounded-full bg-rose-100 text-rose-700 text-sm font-semibold';
+            statusBadge.innerHTML = meta.configured ? '<i data-feather="check-circle" class="w-4 h-4"></i><span>Connected</span>' : '<i data-feather="alert-triangle" class="w-4 h-4"></i><span>Disconnected</span>';
+        }
+
+        if (statusText) {
+            statusText.textContent = meta.configured
+                ? 'OpenAI key detected. Creators can use AI templates and performance coaching.'
+                : 'Add OPEN_API_KEY to your environment variables to enable OpenAI-powered features.';
+        }
+
+        if (cacheDetails) {
+            if (meta.cachedModels) {
+                const expires = meta.cacheExpiresAt ? new Date(meta.cacheExpiresAt).toLocaleTimeString() : 'soon';
+                cacheDetails.textContent = `Cached models: ${meta.cachedModels}. Refreshes at ${expires}.`;
+            } else {
+                cacheDetails.textContent = 'Model cache empty. Load available models to prime the catalog.';
+            }
+        }
+
+        if (typeof feather !== 'undefined') {
+            feather.replace();
+        }
+    }
+
+    function attachTestButtons() {
+        document.querySelectorAll('[data-integration-test]').forEach((button) => {
+            button.addEventListener('click', async (event) => {
+                const provider = event.currentTarget.dataset.integrationTest;
+                if (!provider) {
+                    return;
+                }
+
+                buttonDisabledState(event.currentTarget, true, 'Testing...');
+                try {
+                    const endpoint = provider === 'openai' ? '/api/integrations/openai/test' : `/api/integrations/${provider}/test`;
+                    const response = await fetch(endpoint, { method: 'POST' });
+                    if (!response.ok) {
+                        const errorBody = await response.json().catch(() => ({}));
+                        throw new Error(errorBody?.error || `Test failed (${response.status})`);
+                    }
+                    notification.success('Integration health check succeeded.');
+                } catch (error) {
+                    console.error('Integration test failed', error);
+                    notification.error(error.message || 'Integration test failed.');
+                } finally {
+                    buttonDisabledState(event.currentTarget, false);
+                }
+            });
+        });
+    }
+
+    if (loadModelsBtn) {
+        loadModelsBtn.addEventListener('click', async () => {
+            buttonDisabledState(loadModelsBtn, true, 'Loading...');
+            try {
+                const response = await fetch('/api/integrations/openai/models');
+                if (!response.ok) {
+                    const errorBody = await response.json().catch(() => ({}));
+                    throw new Error(errorBody?.error || `Failed to load models (${response.status})`);
+                }
+
+                const data = await response.json();
+                renderModels(data?.models || []);
+                notification.success('Loaded OpenAI models.');
+            } catch (error) {
+                console.error('Failed to load OpenAI models', error);
+                notification.error(error.message || 'Failed to load OpenAI models.');
+            } finally {
+                buttonDisabledState(loadModelsBtn, false, 'Load available models');
+            }
+        });
+    }
+
+    function renderModels(models) {
+        if (!modelsList) {
+            return;
+        }
+
+        modelsList.innerHTML = '';
+        if (!models.length) {
+            const empty = document.createElement('li');
+            empty.className = 'text-sm text-slate-500';
+            empty.textContent = 'No models returned. Check your OpenAI permissions.';
+            modelsList.appendChild(empty);
+            return;
+        }
+
+        models.slice(0, 15).forEach((model) => {
+            const item = document.createElement('li');
+            item.className = 'flex flex-col rounded-lg border border-slate-200 px-3 py-2';
+
+            const name = document.createElement('span');
+            name.className = 'text-sm font-semibold text-slate-800';
+            name.textContent = model.id;
+
+            const meta = document.createElement('span');
+            meta.className = 'text-xs text-slate-500';
+            const created = model.created ? new Date(model.created * 1000).toLocaleDateString() : 'unknown';
+            meta.textContent = `Owner: ${model.ownedBy || 'unknown'} • Created: ${created}`;
+
+            item.appendChild(name);
+            item.appendChild(meta);
+            modelsList.appendChild(item);
+        });
+    }
+
+    if (connectorForm && connectorResults) {
+        connectorForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const formData = new FormData(connectorForm);
+            const payload = {
+                useCase: String(formData.get('useCase') || '').trim(),
+                audience: String(formData.get('audience') || '').trim() || undefined,
+                tone: String(formData.get('tone') || '').trim() || undefined,
+                channels: (String(formData.get('channels') || '')
+                    .split(',')
+                    .map((value) => value.trim())
+                    .filter(Boolean)) || undefined,
+            };
+
+            if (!payload.useCase) {
+                notification.error('Describe your use case to generate connectors.');
+                return;
+            }
+
+            buttonDisabledState(connectorForm.querySelector('button[type="submit"]'), true, 'Generating...');
+            connectorResults.innerHTML = '<p class="text-sm text-slate-500">Generating connector plan...</p>';
+            if (connectorSummary) {
+                connectorSummary.textContent = '';
+            }
+
+            try {
+                const response = await fetch('/api/integrations/openai/connectors', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+
+                if (!response.ok) {
+                    const errorBody = await response.json().catch(() => ({}));
+                    throw new Error(errorBody?.error || `Failed with status ${response.status}`);
+                }
+
+                const data = await response.json();
+                renderConnectorSuggestions(data);
+                notification.success('Connector plan generated.');
+            } catch (error) {
+                console.error('Failed to generate connector plan', error);
+                notification.error(error.message || 'Failed to generate connector plan.');
+                connectorResults.innerHTML = '<p class="text-sm text-rose-600">Unable to generate connector plan right now.</p>';
+            } finally {
+                buttonDisabledState(connectorForm.querySelector('button[type="submit"]'), false, 'Generate connector plan');
+            }
+        });
+    }
+
+    function renderConnectorSuggestions(data) {
+        if (connectorSummary) {
+            connectorSummary.textContent = data?.summary || 'AI-generated connector automations tailored to your workflow.';
+        }
+
+        const connectors = Array.isArray(data?.connectors) ? data.connectors : [];
+        connectorResults.innerHTML = '';
+
+        if (!connectors.length) {
+            connectorResults.innerHTML = '<p class="text-sm text-slate-500">No structured connectors returned. Review the raw response in the developer console.</p>';
+            return;
+        }
+
+        connectors.forEach((connector) => {
+            const block = document.createElement('article');
+            block.className = 'border border-indigo-200 bg-indigo-50/60 rounded-xl p-4 flex flex-col gap-3';
+
+            const title = document.createElement('h4');
+            title.className = 'text-lg font-semibold text-indigo-900';
+            title.textContent = connector.name;
+
+            const description = document.createElement('p');
+            description.className = 'text-sm text-indigo-800';
+            description.textContent = connector.description;
+
+            const setupList = document.createElement('ul');
+            setupList.className = 'list-disc list-inside text-sm text-indigo-900';
+            (connector.setup || []).forEach((step) => {
+                const item = document.createElement('li');
+                item.textContent = step;
+                setupList.appendChild(item);
+            });
+
+            const automationList = document.createElement('ul');
+            automationList.className = 'list-disc list-inside text-sm text-indigo-900';
+            (connector.automations || []).forEach((automation) => {
+                const item = document.createElement('li');
+                item.textContent = automation;
+                automationList.appendChild(item);
+            });
+
+            const setupLabel = document.createElement('p');
+            setupLabel.className = 'text-xs font-semibold text-indigo-700 uppercase tracking-wide';
+            setupLabel.textContent = 'Setup steps';
+
+            const automationLabel = document.createElement('p');
+            automationLabel.className = 'text-xs font-semibold text-indigo-700 uppercase tracking-wide';
+            automationLabel.textContent = 'Automations';
+
+            block.appendChild(title);
+            block.appendChild(description);
+            block.appendChild(setupLabel);
+            block.appendChild(setupList);
+            block.appendChild(automationLabel);
+            block.appendChild(automationList);
+
+            connectorResults.appendChild(block);
+        });
+    }
+
+    function buttonDisabledState(button, disabled, loadingText) {
+        if (!button) {
+            return;
+        }
+
+        if (disabled) {
+            button.dataset.originalText = button.textContent;
+            button.textContent = loadingText || 'Working...';
+            button.disabled = true;
+            button.classList.add('opacity-70', 'cursor-not-allowed');
+        } else {
+            const original = button.dataset.originalText;
+            if (original) {
+                button.textContent = original;
+            }
+            button.disabled = false;
+            button.classList.remove('opacity-70', 'cursor-not-allowed');
+        }
+    }
+
+    bootstrap();
+});

--- a/integrations.html
+++ b/integrations.html
@@ -14,187 +14,274 @@
 </head>
 <body class="bg-gradient-to-br from-indigo-50 to-purple-100 min-h-screen">
     <custom-navbar></custom-navbar>
-    
-    <main class="container mx-auto px-4 py-8 mt-16">
-        <!-- Page Header -->
-        <div class="text-center mb-12">
-            <h1 class="text-4xl font-bold text-gray-800 mb-4">Powerful Integrations</h1>
-            <p class="text-xl text-gray-600 max-w-2xl mx-auto">
-                Connect CreatorFlow Studio with your favorite tools and platforms
-            </p>
-        </div>
 
-        <!-- Social Media Platforms -->
+    <main class="container mx-auto px-4 py-8 mt-16">
+        <header class="text-center mb-12">
+            <h1 class="text-4xl font-bold text-gray-800 mb-4">CreatorFlow Integrations Hub</h1>
+            <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                Connect automation-ready OpenAI connectors, manage channel hand-offs, and explore native platform integrations
+                without leaving CreatorFlow Studio.
+            </p>
+        </header>
+
+        <!-- OpenAI Integration Control Center -->
+        <section class="mb-16 grid gap-6 lg:grid-cols-2">
+            <article class="bg-white rounded-3xl shadow-xl border border-slate-200 p-8 flex flex-col gap-6">
+                <div class="flex flex-col gap-3">
+                    <div class="flex items-center gap-3">
+                        <span id="openai-status-badge" class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-200 text-slate-700 text-sm font-semibold">
+                            <i data-feather="loader" class="w-4 h-4 animate-spin"></i>
+                            <span>Checking...</span>
+                        </span>
+                        <span class="text-sm font-medium text-slate-500">Server-side OpenAI credential</span>
+                    </div>
+                    <p id="openai-status-text" class="text-slate-600 text-sm">
+                        We'll verify your OPEN_API_KEY and surface connector availability in real time.
+                    </p>
+                </div>
+                <div class="flex flex-wrap items-center gap-3">
+                    <button type="button" data-integration-test="openai" class="px-4 py-2 rounded-lg bg-indigo-600 text-white font-semibold text-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400">
+                        Run connection health check
+                    </button>
+                    <p id="openai-cache-details" class="text-xs text-slate-500">
+                        Model cache status will appear here after the first check.
+                    </p>
+                </div>
+                <div class="bg-slate-50 rounded-2xl p-5 border border-slate-200">
+                    <h3 class="text-lg font-semibold text-slate-800 mb-2">What you unlock</h3>
+                    <ul class="list-disc list-inside text-sm text-slate-600 space-y-1">
+                        <li>AI-assisted content drafting and review workflows</li>
+                        <li>Connector playbooks tailored to each channel</li>
+                        <li>Model catalog visibility for compliance and QA</li>
+                    </ul>
+                </div>
+            </article>
+
+            <article class="bg-white rounded-3xl shadow-xl border border-slate-200 p-8 flex flex-col gap-6">
+                <header class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-2xl font-semibold text-slate-900">OpenAI Model Catalog</h3>
+                        <p class="text-sm text-slate-500">Review available models before routing workloads.</p>
+                    </div>
+                    <button id="load-openai-models" type="button" class="px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold text-sm hover:bg-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-400">
+                        Load available models
+                    </button>
+                </header>
+                <ul id="openai-model-list" class="grid gap-3 max-h-64 overflow-y-auto pr-1" aria-live="polite">
+                    <li class="text-sm text-slate-500">Model list populates after loading.</li>
+                </ul>
+            </article>
+        </section>
+
+        <!-- Connector Catalog -->
+        <section class="mb-16">
+            <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4 mb-8">
+                <div>
+                    <h2 class="text-3xl font-bold text-gray-800">OpenAI connectors ready to launch</h2>
+                    <p class="text-gray-600 max-w-2xl">
+                        Every connector below is powered by your server-side OpenAI key and respects CreatorFlow guardrails. Toggle
+                        health checks to confirm connectivity and review documentation before rollout.
+                    </p>
+                </div>
+                <span class="text-sm text-slate-500">Catalog updates automatically when credentials change.</span>
+            </div>
+            <p id="integration-empty-state" class="text-center text-sm text-slate-500 bg-white/80 border border-dashed border-slate-300 rounded-2xl py-6">
+                Loading integration catalog...
+            </p>
+            <div id="integration-grid" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3"></div>
+        </section>
+
+        <!-- Connector Playbook Generator -->
+        <section class="mb-20 grid gap-8 lg:grid-cols-2">
+            <article class="bg-white rounded-3xl shadow-xl border border-slate-200 p-8">
+                <h2 class="text-3xl font-bold text-gray-800 mb-4">Design a connector playbook</h2>
+                <p class="text-gray-600 mb-6">
+                    Describe the workflow you want to automate and we will create battle-tested OpenAI connector steps plus ready-to-run automations.
+                </p>
+                <form id="connector-suggestion-form" class="space-y-5">
+                    <div>
+                        <label for="useCase" class="block text-sm font-semibold text-slate-700 mb-2">What do you want to automate?</label>
+                        <textarea id="useCase" name="useCase" rows="4" class="w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400" placeholder="Example: Repurpose my YouTube scripts into Instagram Reels with CTA variants." required></textarea>
+                    </div>
+                    <div class="grid gap-5 md:grid-cols-2">
+                        <div>
+                            <label for="audience" class="block text-sm font-semibold text-slate-700 mb-2">Primary audience</label>
+                            <input id="audience" name="audience" type="text" class="w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400" placeholder="Growth marketers, community managers, ...">
+                        </div>
+                        <div>
+                            <label for="tone" class="block text-sm font-semibold text-slate-700 mb-2">Preferred tone</label>
+                            <input id="tone" name="tone" type="text" class="w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400" placeholder="Analytical, playful, authoritative...">
+                        </div>
+                    </div>
+                    <div>
+                        <label for="channels" class="block text-sm font-semibold text-slate-700 mb-2">Priority channels</label>
+                        <input id="channels" name="channels" type="text" class="w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400" placeholder="Comma-separated list (e.g. Instagram, TikTok)">
+                    </div>
+                    <button type="submit" class="w-full md:w-auto inline-flex justify-center px-6 py-3 rounded-xl bg-indigo-600 text-white font-semibold text-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400">
+                        Generate connector plan
+                    </button>
+                </form>
+            </article>
+
+            <article class="bg-white rounded-3xl shadow-xl border border-slate-200 p-8 flex flex-col gap-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-2xl font-semibold text-slate-900">AI-generated playbook</h3>
+                        <p id="connector-summary" class="text-sm text-slate-500">
+                            Results appear here. Each plan includes setup requirements and automated hand-offs.
+                        </p>
+                    </div>
+                    <i data-feather="zap" class="w-8 h-8 text-amber-500"></i>
+                </div>
+                <div id="connector-suggestions" class="space-y-4" aria-live="polite">
+                    <p class="text-sm text-slate-500">Submit your workflow to receive recommended connectors.</p>
+                </div>
+            </article>
+        </section>
+
+        <!-- Existing platform overview sections -->
         <section class="mb-16">
             <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">Social Media Platforms</h2>
             <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-                <!-- Instagram -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-gradient-to-br from-pink-500 to-purple-600 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="instagram" class="text-white w-8 h-8"></i>
+                    <div class="w-16 h-16 bg-gradient-to-br from-pink-500 to-purple-600 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="instagram" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Instagram</h3>
+                    <p class="text-gray-600 text-center">Direct publishing for posts, stories, and reels</p>
                 </div>
-                <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Instagram</h3>
-                <p class="text-gray-600 text-center">Direct publishing for posts, stories, and reels</p>
-            </div>
-            
-            <!-- TikTok -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-black rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="video" class="text-white w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">TikTok</h3>
-                <p class="text-gray-600 text-center">Schedule and publish videos directly</p>
-            </div>
-            
-            <!-- YouTube -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-red-100 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="youtube" class="text-red-600 w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">YouTube</h3>
-                <p class="text-gray-600 text-center">Upload videos and manage descriptions</p>
-            </div>
-            
-            <!-- Twitter -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-blue-100 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="twitter" class="text-blue-600 w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Twitter</h3>
-                <p class="text-gray-600 text-center">Schedule tweets and threads</p>
-            </div>
-            
-            <!-- Facebook -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-blue-200 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="facebook" class="text-blue-800 w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Facebook</h3>
-                <p class="text-gray-600 text-center">Post to pages and groups</p>
-            </div>
-            
-            <!-- LinkedIn -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-blue-300 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="linkedin" class="text-white w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">LinkedIn</h3>
-                <p class="text-gray-600 text-center">Share professional content</p>
-            </div>
-            
-            <!-- Pinterest -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-red-200 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="pinterest" class="text-red-800 w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Pinterest</h3>
-                <p class="text-gray-600 text-center">Pin images and create boards</p>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-black rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="video" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">TikTok</h3>
+                    <p class="text-gray-600 text-center">Schedule and publish videos directly</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-red-100 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="youtube" class="text-red-600 w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">YouTube</h3>
+                    <p class="text-gray-600 text-center">Upload videos and manage descriptions</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-blue-100 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="twitter" class="text-blue-600 w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Twitter</h3>
+                    <p class="text-gray-600 text-center">Schedule tweets and threads</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-blue-200 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="facebook" class="text-blue-800 w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Facebook</h3>
+                    <p class="text-gray-600 text-center">Post to pages and groups</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-blue-300 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="linkedin" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">LinkedIn</h3>
+                    <p class="text-gray-600 text-center">Share professional content</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-red-200 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="pinterest" class="text-red-800 w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Pinterest</h3>
+                    <p class="text-gray-600 text-center">Pin images and create boards</p>
+                </div>
             </div>
         </section>
 
-        <!-- Content Management Tools -->
         <section class="mb-16">
             <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">Content Management Tools</h2>
             <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <!-- Canva -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
                     <div class="w-16 h-16 bg-gradient-to-r from-blue-400 to-purple-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="image" class="text-white w-8 h-8"></i>
-                </div>
-                <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Canva</h3>
+                        <i data-feather="image" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Canva</h3>
                     <p class="text-gray-600 text-center">Import designs and collaborate on visuals</p>
                 </div>
-                
-                <!-- Notion -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
                     <div class="w-16 h-16 bg-gray-800 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="file-text" class="text-white w-8 h-8"></i>
-                </div>
-                <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Notion</h3>
+                        <i data-feather="file-text" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Notion</h3>
                     <p class="text-gray-600 text-center">Sync with your content database</p>
                 </div>
-                
-                <!-- Airtable -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
                     <div class="w-16 h-16 bg-blue-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="grid" class="text-white w-8 h-8"></i>
-                </div>
-                <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Airtable</h3>
+                        <i data-feather="grid" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Airtable</h3>
                     <p class="text-gray-600 text-center">Organize content in custom bases</p>
                 </div>
-                
-                <!-- Google Drive -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
                     <div class="w-16 h-16 bg-green-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="hard-drive" class="text-white w-8 h-8"></i>
-                </div>
-                <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Google Drive</h3>
+                        <i data-feather="hard-drive" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Google Drive</h3>
                     <p class="text-gray-600 text-center">Store and access all your files</p>
                 </div>
-                
-                <!-- Dropbox -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
                     <div class="w-16 h-16 bg-blue-600 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                    <i data-feather="folder" class="text-white w-8 h-8"></i>
-                </div>
-                <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Dropbox</h3>
+                        <i data-feather="folder" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Dropbox</h3>
                     <p class="text-gray-600 text-center">Sync files across devices</p>
                 </div>
             </div>
         </section>
 
-        <!-- Analytics & SEO Tools -->
         <section class="mb-16">
-            <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">Analytics & SEO Tools</h2>
+            <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">Analytics &amp; SEO Tools</h2>
             <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <!-- Google Analytics -->
                 <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-orange-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                <i data-feather="bar-chart-2" class="text-white w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Google Analytics</h3>
-                <p class="text-gray-600 text-center">Track content performance</p>
-            </div>
-            
-            <!-- SEMrush -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-red-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                <i data-feather="search" class="text-white w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">SEMrush</h3>
-                <p class="text-gray-600 text-center">SEO optimization insights</p>
-            </div>
-            
-            <!-- Ahrefs -->
-            <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <div class="w-16 h-16 bg-purple-600 rounded-lg flex items-center justify-center mb-4 mx-auto">
-                <i data-feather="globe" class="text-white w-8 h-8"></i>
-            </div>
-            <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Ahrefs</h3>
-                <p class="text-gray-600 text-center">Competitor analysis and tracking</p>
+                    <div class="w-16 h-16 bg-orange-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="bar-chart-2" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Google Analytics</h3>
+                    <p class="text-gray-600 text-center">Track content performance</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-red-500 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="search" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">SEMrush</h3>
+                    <p class="text-gray-600 text-center">SEO optimization insights</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                    <div class="w-16 h-16 bg-purple-600 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <i data-feather="globe" class="text-white w-8 h-8"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-3 text-center">Ahrefs</h3>
+                    <p class="text-gray-600 text-center">Competitor analysis and tracking</p>
+                </div>
             </div>
         </section>
 
-        <!-- CTA Section -->
         <section class="text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white rounded-2xl p-12">
             <h2 class="text-3xl font-bold mb-4">Need Another Integration?</h2>
             <p class="text-xl mb-8 max-w-2xl mx-auto">
-                We're constantly expanding our integration ecosystem. Let us know what tools you'd like to see next.</p>
+                We're constantly expanding our integration ecosystem. Let us know what tools you'd like to see next.
+            </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
                 <a href="contact.html" class="bg-white text-purple-600 hover:bg-purple-50 px-8 py-3 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105">
                     Request Integration
                 </a>
                 <a href="signup.html" class="border border-white text-white hover:bg-white hover:text-purple-600 px-8 py-3 rounded-lg font-semibold transition-all duration-300">
-                        Start Free Trial
-                    </a>
-                </div>
-</div>
+                    Start Free Trial
+                </a>
+            </div>
         </section>
     </main>
 
     <custom-footer></custom-footer>
-    <script src="assets/js/admin.js"></script>
     <script src="script.js"></script>
+    <script src="assets/js/integrations.js"></script>
     <script>
         feather.replace();
     </script>


### PR DESCRIPTION
## Summary
- refresh the integrations experience with an OpenAI control center, dynamic connector catalog, and AI-generated playbook tools
- expose REST endpoints for integration catalog, connector planning, health checks, and model inventory using the existing OpenAI API key
- add a dedicated front-end controller to fetch statuses, run tests, and render connector recommendations with graceful fallbacks

## Testing
- `npm start`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177c64224c8333a6d659b258e0a5f8)