### PR TITLE
feat: add OpenAI media endpoints for videos and images

### DIFF
--- a/lib/openai-media.js
+++ b/lib/openai-media.js
@@ -1,0 +1,386 @@
+import { OpenAiRequestError } from './openai.js';
+
+const OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_VIDEO_TIMEOUT_MS = 120_000;
+const DEFAULT_IMAGE_TIMEOUT_MS = 30_000;
+
+function ensureApiKey(apiKey) {
+  if (typeof apiKey !== 'string' || apiKey.trim().length === 0) {
+    throw new Error('OPEN_API_KEY not configured on server. Provide OPEN_API_KEY or OPEN_AI_KEY.');
+  }
+}
+
+function createTimeoutSignal(timeoutMs = 8000) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  return {
+    signal: controller.signal,
+    dispose: () => clearTimeout(timeout),
+  };
+}
+
+function pickDefined(input) {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined && value !== null && value !== '' && !Number.isNaN(value))
+  );
+}
+
+async function parseJsonResponse(response) {
+  const rawBody = await response.text().catch(() => '');
+
+  if (!response.ok) {
+    throw new OpenAiRequestError(`OpenAI request failed: ${response.status}`, {
+      status: response.status,
+      body: rawBody,
+    });
+  }
+
+  if (!rawBody) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(rawBody);
+  } catch (error) {
+    throw new OpenAiRequestError('OpenAI returned malformed JSON response.', {
+      status: response.status,
+      body: rawBody,
+    });
+  }
+}
+
+function normaliseHeaders(response) {
+  const headers = {};
+  if (response?.headers && typeof response.headers.forEach === 'function') {
+    response.headers.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+  }
+  return headers;
+}
+
+export async function createVideoJob({
+  apiKey,
+  prompt,
+  model,
+  seconds,
+  size,
+  quality,
+  inputReference,
+  timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  if (typeof fetchImpl !== 'function') {
+    throw new TypeError('A fetch implementation must be provided.');
+  }
+
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const hasFile = Boolean(inputReference && inputReference.buffer && inputReference.buffer.length > 0);
+    let body;
+    const headers = {
+      Authorization: `Bearer ${apiKey}`,
+    };
+
+    if (hasFile) {
+      const formData = new FormData();
+      formData.append('prompt', prompt);
+      if (model) formData.append('model', model);
+      if (seconds) formData.append('seconds', String(seconds));
+      if (size) formData.append('size', size);
+      if (quality) formData.append('quality', quality);
+
+      const blob = new Blob([inputReference.buffer], {
+        type: inputReference.mimetype || 'application/octet-stream',
+      });
+      formData.append('input_reference', blob, inputReference.filename || 'input-reference');
+      body = formData;
+    } else {
+      body = JSON.stringify(
+        pickDefined({
+          prompt,
+          model,
+          seconds,
+          size,
+          quality,
+        })
+      );
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/videos`, {
+      method: 'POST',
+      headers,
+      body,
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+export async function remixVideoJob({
+  apiKey,
+  videoId,
+  prompt,
+  timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/videos/${encodeURIComponent(videoId)}/remix`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ prompt }),
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+export async function listVideoJobs({
+  apiKey,
+  after,
+  limit,
+  order,
+  timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const url = new URL(`${OPENAI_BASE_URL}/videos`);
+    if (after) url.searchParams.set('after', after);
+    if (typeof limit === 'number') url.searchParams.set('limit', String(limit));
+    if (order) url.searchParams.set('order', order);
+
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+export async function retrieveVideoJob({ apiKey, videoId, timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS, fetchImpl = globalThis.fetch }) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/videos/${encodeURIComponent(videoId)}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+export async function deleteVideoJob({ apiKey, videoId, timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS, fetchImpl = globalThis.fetch }) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/videos/${encodeURIComponent(videoId)}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+export async function downloadVideoContent({
+  apiKey,
+  videoId,
+  variant,
+  timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const url = new URL(`${OPENAI_BASE_URL}/videos/${encodeURIComponent(videoId)}/content`);
+    if (variant) {
+      url.searchParams.set('variant', variant);
+    }
+
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal,
+    });
+
+    const headers = normaliseHeaders(response);
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    if (!response.ok) {
+      throw new OpenAiRequestError(`OpenAI request failed: ${response.status}`, {
+        status: response.status,
+        body: buffer.toString('utf8'),
+      });
+    }
+
+    return {
+      status: response.status,
+      headers,
+      buffer,
+    };
+  } finally {
+    dispose();
+  }
+}
+
+export async function createImageGeneration({
+  apiKey,
+  payload,
+  timeoutMs = DEFAULT_IMAGE_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/images/generations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+function appendFiles(formData, files, field) {
+  if (!Array.isArray(files)) {
+    return;
+  }
+
+  for (const file of files) {
+    if (!file || !file.buffer) {
+      continue;
+    }
+
+    const blob = new Blob([file.buffer], { type: file.mimetype || 'application/octet-stream' });
+    formData.append(field, blob, file.filename || field);
+  }
+}
+
+export async function createImageEdit({
+  apiKey,
+  images,
+  mask,
+  options = {},
+  timeoutMs = DEFAULT_IMAGE_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const formData = new FormData();
+    appendFiles(formData, images, 'image');
+
+    if (mask && mask.buffer) {
+      const blob = new Blob([mask.buffer], { type: mask.mimetype || 'image/png' });
+      formData.append('mask', blob, mask.filename || 'mask.png');
+    }
+
+    Object.entries(options).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        formData.append(key, typeof value === 'number' ? String(value) : value);
+      }
+    });
+
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/images/edits`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: formData,
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}
+
+export async function createImageVariation({
+  apiKey,
+  image,
+  options = {},
+  timeoutMs = DEFAULT_IMAGE_TIMEOUT_MS,
+  fetchImpl = globalThis.fetch,
+}) {
+  ensureApiKey(apiKey);
+  const { signal, dispose } = createTimeoutSignal(timeoutMs);
+
+  try {
+    const formData = new FormData();
+    if (image && image.buffer) {
+      const blob = new Blob([image.buffer], { type: image.mimetype || 'image/png' });
+      formData.append('image', blob, image.filename || 'variation.png');
+    }
+
+    Object.entries(options).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        formData.append(key, typeof value === 'number' ? String(value) : value);
+      }
+    });
+
+    const response = await fetchImpl(`${OPENAI_BASE_URL}/images/variations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: formData,
+      signal,
+    });
+
+    return await parseJsonResponse(response);
+  } finally {
+    dispose();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
+        "multer": "^2.0.2",
         "passport": "^0.7.0",
         "passport-facebook": "^3.0.0",
-        "passport-google-oauth20": "^2.0.0"
+        "passport-google-oauth20": "^2.0.0",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/accepts": {
@@ -30,6 +32,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -70,6 +78,23 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -106,6 +131,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -581,11 +621,50 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -795,6 +874,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -962,6 +1055,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -983,6 +1093,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",
@@ -1011,6 +1127,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1027,6 +1149,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "test": "node --test"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "dotenv": "^16.3.1",
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
     "express-session": "^1.17.3",
+    "multer": "^2.0.2",
     "passport": "^0.7.0",
     "passport-facebook": "^3.0.0",
-    "passport-google-oauth20": "^2.0.0"
+    "passport-google-oauth20": "^2.0.0",
+    "zod": "^3.25.76"
   },
   "keywords": [
     "ai",

--- a/tests/openai-media.test.js
+++ b/tests/openai-media.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createImageGeneration,
+  createVideoJob,
+  downloadVideoContent,
+} from '../lib/openai-media.js';
+
+test('createVideoJob posts JSON payload when no file is provided', async () => {
+  let captured;
+  const fakeFetch = async (url, options) => {
+    captured = { url: url.toString(), options };
+    return {
+      ok: true,
+      status: 200,
+      headers: { forEach: () => {} },
+      text: async () => JSON.stringify({ id: 'video_123' }),
+    };
+  };
+
+  const result = await createVideoJob({
+    apiKey: 'test-key',
+    prompt: 'A prompt',
+    fetchImpl: fakeFetch,
+    timeoutMs: 10,
+  });
+
+  assert.equal(result.id, 'video_123');
+  assert.equal(captured.url, 'https://api.openai.com/v1/videos');
+  assert.equal(captured.options.method, 'POST');
+  assert.equal(captured.options.headers.Authorization, 'Bearer test-key');
+  const body = JSON.parse(captured.options.body);
+  assert.equal(body.prompt, 'A prompt');
+});
+
+test('createVideoJob sends multipart payload when input reference is present', async () => {
+  let captured;
+  const fakeFetch = async (_url, options) => {
+    captured = options;
+    return {
+      ok: true,
+      status: 200,
+      headers: { forEach: () => {} },
+      text: async () => JSON.stringify({ id: 'video_456' }),
+    };
+  };
+
+  const buffer = Buffer.from('hello');
+  await createVideoJob({
+    apiKey: 'test-key',
+    prompt: 'With reference',
+    inputReference: { buffer, mimetype: 'image/png', filename: 'ref.png' },
+    fetchImpl: fakeFetch,
+    timeoutMs: 10,
+  });
+
+  assert.ok(captured.body instanceof FormData);
+  assert.equal(captured.headers['Content-Type'], undefined);
+});
+
+test('downloadVideoContent returns buffer and response metadata', async () => {
+  const fakeFetch = async () => {
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        forEach: (fn) => {
+          fn('video/mp4', 'content-type');
+          fn('attachment; filename="video.mp4"', 'content-disposition');
+        },
+      },
+      arrayBuffer: async () => new TextEncoder().encode('data').buffer,
+    };
+  };
+
+  const result = await downloadVideoContent({
+    apiKey: 'test-key',
+    videoId: 'video_123',
+    fetchImpl: fakeFetch,
+    timeoutMs: 10,
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(result.headers['content-type'], 'video/mp4');
+  assert.equal(result.headers['content-disposition'], 'attachment; filename="video.mp4"');
+  assert.equal(result.buffer.toString(), 'data');
+});
+
+test('createImageGeneration propagates API errors', async () => {
+  const fakeFetch = async () => ({
+    ok: false,
+    status: 401,
+    headers: { forEach: () => {} },
+    text: async () => 'unauthorized',
+  });
+
+  await assert.rejects(
+    () =>
+      createImageGeneration({
+        apiKey: 'test-key',
+        payload: { prompt: 'Test' },
+        fetchImpl: fakeFetch,
+        timeoutMs: 10,
+      }),
+    /OpenAI request failed: 401/
+  );
+});


### PR DESCRIPTION
## Summary
- add multer and zod dependencies to support validated media uploads for OpenAI
- introduce OpenAI media client helpers and secured video/image Express routes that reuse the OPEN_AI_KEY fallback
- cover media client behaviours with new node:test suite

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691797669c508333924a5c602a01d9ab)