### PR TITLE
feat: adopt neon dark theme and refresh navigation

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -1,163 +1,444 @@
+const NAV_ITEMS = [
+    { href: 'index.html', label: 'Home' },
+    { href: 'dashboard.html', label: 'Dashboard' },
+    { href: 'editor.html', label: 'Editor' },
+    { href: 'templates.html', label: 'Templates' },
+    { href: 'pricing.html', label: 'Pricing' },
+    { href: 'integrations.html', label: 'Integrations' },
+    { href: 'help.html', label: 'Help' },
+    { href: 'admin-login.html', label: 'Admin' }
+];
+
+const AUTH_ACTIONS = [
+    { href: 'login.html', label: 'Sign In', variant: 'ghost' },
+    { href: 'signup.html', label: 'Start Free Trial', variant: 'primary' }
+];
+
 class CustomNavbar extends HTMLElement {
+    constructor() {
+        super();
+        this.handleRouteChange = () => this.highlightActiveLink();
+        this.handleCloseOnEscape = null;
+    }
+
     connectedCallback() {
         this.attachShadow({ mode: 'open' });
+
+        const desktopLinks = NAV_ITEMS.map(
+            ({ href, label }) => `
+                <a href="${href}" class="nav-link" data-nav>
+                    ${label}
+                </a>
+            `
+        ).join('');
+
+        const mobileLinks = NAV_ITEMS.map(
+            ({ href, label }) => `
+                <a href="${href}" class="nav-link mobile-link" data-nav>
+                    ${label}
+                </a>
+            `
+        ).join('');
+
+        const authLinks = AUTH_ACTIONS.map(({ href, label, variant }) => {
+            if (variant === 'primary') {
+                return `
+                    <a href="${href}" class="nav-cta" data-auth>
+                        ${label}
+                    </a>
+                `;
+            }
+
+            return `
+                <a href="${href}" class="nav-action" data-auth>
+                    ${label}
+                </a>
+            `;
+        }).join('');
+
         this.shadowRoot.innerHTML = `
             <style>
+                :host {
+                    display: contents;
+                }
+
                 .navbar {
-                    background: rgba(255, 255, 255, 0.1);
-                    backdrop-filter: blur(20px) saturate(180%);
-                    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                    z-index: 1000;
+                    background: linear-gradient(135deg, rgba(7, 17, 35, 0.92), rgba(3, 9, 26, 0.88));
+                    backdrop-filter: blur(24px) saturate(180%);
+                    border-bottom: 1px solid rgba(56, 189, 248, 0.18);
                     transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-                    box-shadow: 
-                        0 8px 32px rgba(0, 0, 0, 0.08);
+                    box-shadow:
+                        0 16px 40px rgba(2, 8, 23, 0.6),
+                        inset 0 1px 0 rgba(148, 163, 184, 0.05);
+                    padding: 0 1.25rem;
                 }
-                
+
                 .navbar-scrolled {
-                    background: rgba(255, 255, 255, 0.12);
-                    backdrop-filter: blur(25px);
-                    box-shadow: 
-                        0 12px 40px rgba(0, 0, 0, 0.1),
-                        inset 0 1px 0 rgba(255, 255, 255, 0.2);
+                    background: linear-gradient(135deg, rgba(4, 12, 31, 0.95), rgba(2, 6, 20, 0.95));
+                    border-bottom-color: rgba(56, 189, 248, 0.28);
+                    box-shadow:
+                        0 20px 60px rgba(2, 8, 23, 0.7),
+                        inset 0 1px 0 rgba(148, 163, 184, 0.08);
                 }
-                
+
+                .nav-shell {
+                    width: min(1100px, calc(100% - 2rem));
+                    margin: 0 auto;
+                    padding: 0.9rem 0;
+                    display: flex;
+                    align-items: center;
+                    gap: 1.5rem;
+                }
+
+                .brand {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 0.8rem;
+                    text-decoration: none;
+                    color: #e2e8f0;
+                    font-weight: 600;
+                    letter-spacing: 0.08em;
+                    text-transform: uppercase;
+                }
+
+                .brand-icon {
+                    width: 40px;
+                    height: 40px;
+                    border-radius: 14px;
+                    display: grid;
+                    place-items: center;
+                    background: radial-gradient(circle at 25% 25%, rgba(56, 189, 248, 0.9), rgba(2, 6, 23, 0.9));
+                    border: 1px solid rgba(56, 189, 248, 0.25);
+                    box-shadow: 0 10px 25px rgba(8, 145, 178, 0.4), inset 0 1px 0 rgba(148, 163, 184, 0.12);
+                }
+
+                .brand-name {
+                    font-size: 0.95rem;
+                    background: linear-gradient(120deg, rgba(56, 189, 248, 0.95), rgba(94, 234, 212, 0.95));
+                    -webkit-background-clip: text;
+                    -webkit-text-fill-color: transparent;
+                    text-shadow: 0 0 16px rgba(56, 189, 248, 0.35);
+                }
+
+                .desktop-links {
+                    display: flex;
+                    align-items: center;
+                    gap: 1.4rem;
+                    margin-left: auto;
+                }
+
                 .nav-link {
                     position: relative;
-                    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+                    color: #cbd5f5;
+                    font-weight: 500;
+                    letter-spacing: 0.01em;
+                    text-decoration: none;
+                    transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
                 }
-                
-                .nav-link:hover {
-                    color: #7c3aed;
-                    transform: translateY(-2px);
-                }
-                
+
                 .nav-link::after {
                     content: '';
                     position: absolute;
+                    left: 0;
+                    bottom: -6px;
                     width: 0;
                     height: 2px;
-                    bottom: -4px;
-                    left: 0;
-                    background: linear-gradient(135deg, #7c3aed, #4f46e5);
-                    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+                    background: linear-gradient(120deg, rgba(56, 189, 248, 1), rgba(20, 184, 166, 1));
+                    box-shadow: 0 0 12px rgba(34, 211, 238, 0.6);
+                    transition: width 0.35s cubic-bezier(0.4, 0, 0.2, 1);
                 }
-                
-                .nav-link:hover::after {
+
+                .nav-link:hover,
+                .nav-link:focus-visible {
+                    color: #ffffff;
+                    transform: translateY(-2px);
+                }
+
+                .nav-link:hover::after,
+                .nav-link:focus-visible::after,
+                .nav-link.is-active::after,
+                .nav-link[aria-current='page']::after {
                     width: 100%;
                 }
-                
-                .mobile-menu {
-                    transform: translateX(-100%);
-                    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+
+                .nav-link.is-active,
+                .nav-link[aria-current='page'] {
+                    color: #ffffff;
+                    text-shadow: 0 0 12px rgba(56, 189, 248, 0.45);
                 }
-                
+
+                .actions {
+                    display: flex;
+                    align-items: center;
+                    gap: 1.2rem;
+                    margin-left: 1.2rem;
+                }
+
+                .nav-action {
+                    color: #94a3b8;
+                    text-decoration: none;
+                    font-weight: 500;
+                    transition: color 0.3s ease;
+                }
+
+                .nav-action:hover,
+                .nav-action:focus-visible {
+                    color: #e2e8f0;
+                }
+
+                .nav-cta {
+                    position: relative;
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 0.55rem 1.4rem;
+                    border-radius: 999px;
+                    background: linear-gradient(120deg, rgba(59, 130, 246, 0.95) 0%, rgba(2, 132, 199, 0.95) 100%);
+                    color: #ffffff;
+                    font-weight: 600;
+                    text-decoration: none;
+                    box-shadow: 0 18px 36px rgba(34, 211, 238, 0.35), 0 0 24px rgba(56, 189, 248, 0.45);
+                    transition: transform 0.35s ease, box-shadow 0.35s ease;
+                }
+
+                .nav-cta::after {
+                    content: '';
+                    position: absolute;
+                    inset: -1px;
+                    border-radius: inherit;
+                    border: 1px solid rgba(148, 163, 184, 0.2);
+                    opacity: 0.6;
+                }
+
+                .nav-cta:hover,
+                .nav-cta:focus-visible {
+                    transform: translateY(-2px);
+                    box-shadow: 0 20px 44px rgba(34, 211, 238, 0.4), 0 0 32px rgba(56, 189, 248, 0.55);
+                }
+
+                .mobile-toggle {
+                    display: none;
+                    padding: 0.5rem;
+                    border-radius: 12px;
+                    border: 1px solid rgba(56, 189, 248, 0.18);
+                    background: rgba(7, 17, 35, 0.6);
+                    color: #e2e8f0;
+                    cursor: pointer;
+                    transition: border-color 0.3s ease, transform 0.3s ease;
+                }
+
+                .mobile-toggle:hover,
+                .mobile-toggle:focus-visible {
+                    border-color: rgba(56, 189, 248, 0.4);
+                    transform: translateY(-2px);
+                }
+
+                .mobile-scrim {
+                    position: fixed;
+                    inset: 0;
+                    background: rgba(2, 6, 23, 0.65);
+                    backdrop-filter: blur(6px);
+                    opacity: 0;
+                    pointer-events: none;
+                    transition: opacity 0.4s ease;
+                    z-index: 999;
+                }
+
+                .mobile-scrim.visible {
+                    opacity: 1;
+                    pointer-events: auto;
+                }
+
+                .mobile-menu {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    bottom: 0;
+                    width: min(360px, 82vw);
+                    padding: 1.75rem;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.5rem;
+                    background: linear-gradient(145deg, rgba(5, 16, 42, 0.96), rgba(3, 10, 28, 0.92));
+                    backdrop-filter: blur(30px) saturate(160%);
+                    transform: translateX(-120%);
+                    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+                    z-index: 1000;
+                    overflow-y: auto;
+                    border-right: 1px solid rgba(56, 189, 248, 0.2);
+                }
+
                 .mobile-menu.open {
                     transform: translateX(0);
                 }
 
-                /* Enhanced mobile menu with glass effect */
-                .mobile-menu {
-                    background: rgba(255, 255, 255, 0.08);
-                    backdrop-filter: blur(25px);
+                .mobile-header {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    gap: 1rem;
+                }
+
+                .mobile-title {
+                    font-size: 0.85rem;
+                    letter-spacing: 0.14em;
+                    text-transform: uppercase;
+                    color: #94a3b8;
+                }
+
+                .mobile-close {
+                    border: none;
+                    background: none;
+                    color: #e2e8f0;
+                    display: inline-flex;
+                    padding: 0.25rem;
+                    border-radius: 8px;
+                    cursor: pointer;
+                    transition: transform 0.3s ease, color 0.3s ease;
+                }
+
+                .mobile-close:hover,
+                .mobile-close:focus-visible {
+                    color: #ffffff;
+                    transform: rotate(90deg);
+                }
+
+                .mobile-links {
+                    display: grid;
+                    gap: 1rem;
+                }
+
+                .mobile-divider {
+                    height: 1px;
+                    background: linear-gradient(90deg, rgba(56, 189, 248, 0.2), rgba(2, 6, 23, 0));
+                    margin: 0.25rem 0 0.5rem;
+                }
+
+                .mobile-auth {
+                    display: grid;
+                    gap: 0.75rem;
+                }
+
+                .mobile-link {
+                    font-size: 1rem;
+                }
+
+                .mobile-link::after {
+                    bottom: -4px;
+                }
+
+                .mobile-cta {
+                    display: inline-flex;
+                    justify-content: center;
+                    align-items: center;
+                    border-radius: 999px;
+                    padding: 0.7rem 1.4rem;
+                    background: linear-gradient(120deg, rgba(59, 130, 246, 0.95) 0%, rgba(2, 132, 199, 0.95) 100%);
+                    color: #ffffff;
+                    font-weight: 600;
+                    text-decoration: none;
+                    box-shadow: 0 18px 36px rgba(34, 211, 238, 0.35);
+                }
+
+                .mobile-menu:focus {
+                    outline: none;
+                }
+
+                .feather-icon {
+                    width: 20px;
+                    height: 20px;
+                    stroke-width: 1.8;
+                }
+
+                @media (max-width: 960px) {
+                    .desktop-links,
+                    .actions {
+                        display: none;
+                    }
+
+                    .mobile-toggle {
+                        display: inline-flex;
+                    }
+
+                    .nav-shell {
+                        padding-right: 0;
+                    }
+                }
+
+                @media (max-width: 640px) {
+                    .nav-shell {
+                        width: min(100%, 100% - 1.5rem);
+                        padding: 0.85rem 0;
+                    }
+
+                    .brand-name {
+                        font-size: 0.9rem;
+                    }
                 }
             </style>
-            <nav class="navbar fixed top-0 left-0 right-0 z-50 header-container">
-                <div class="container mx-auto px-4 py-3">
-                    <div class="flex items-center justify-between">
-                        <!-- Logo -->
-                        <a href="index.html" class="flex items-center space-x-2">
-                            <div class="w-8 h-8 bg-gradient-to-r from-purple-600 to-indigo-600 rounded-lg flex items-center justify-center">
-                                <i data-feather="wand" class="text-white w-4 h-4"></i>
-                            </div>
-                            <span class="text-xl font-bold bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent">
-                                CreatorFlow
-                            </span>
-                        </a>
-<!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-6">
-                            <a href="index.html" class="nav-link text-gray-700 font-medium">Home</a>
-                            <a href="dashboard.html" class="nav-link text-gray-700 font-medium">Dashboard</a>
-                            <a href="editor.html" class="nav-link text-gray-700 font-medium">Editor</a>
-                        <a href="templates.html" class="nav-link text-gray-700 font-medium">Templates</a>
-                        <a href="pricing.html" class="nav-link text-gray-700 font-medium">Pricing</a>
-                        <a href="integrations.html" class="nav-link text-gray-700 font-medium">Integrations</a>
-                        <a href="help.html" class="nav-link text-gray-700 font-medium">Help</a>
-                        <a href="admin-login.html" class="nav-link text-gray-700 font-medium">Admin</a>
-</div>
-<!-- Auth Buttons -->
-                        <div class="hidden md:flex items-center space-x-4">
-                        <a href="login.html" class="text-gray-700 hover:text-purple-600 font-medium transition-colors duration-300">
-                            Sign In
-                        </a>
-                        <a href="signup.html" class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-medium transition-all duration-300 hover:shadow-lg">
-                                Start Free Trial
-                            </a>
-</div>
-<!-- Mobile Menu Button -->
-                        <button class="md:hidden p-2 rounded-lg hover:bg-gray-100 transition-colors duration-300" id="mobile-menu-button">
-                                <i data-feather="menu" class="w-6 h-6 text-gray-700"></i>
+            <nav class="navbar">
+                <div class="nav-shell">
+                    <a href="index.html" class="brand">
+                        <span class="brand-icon" aria-hidden="true">
+                            <i data-feather="zap"></i>
+                        </span>
+                        <span class="brand-name">CreatorFlow</span>
+                    </a>
+                    <div class="desktop-links" role="navigation" aria-label="Primary">
+                        ${desktopLinks}
+                    </div>
+                    <div class="actions">
+                        ${authLinks}
+                    </div>
+                    <button class="mobile-toggle" id="mobile-menu-button" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open navigation menu">
+                        <i data-feather="menu"></i>
+                    </button>
+                </div>
+                <div class="mobile-scrim" hidden></div>
+                <div class="mobile-menu" id="mobile-menu" role="dialog" aria-modal="true" aria-label="Site navigation" tabindex="-1">
+                    <div class="mobile-header">
+                        <span class="mobile-title">Navigation</span>
+                        <button class="mobile-close" id="mobile-menu-close" aria-label="Close navigation menu">
+                            <i data-feather="x"></i>
                         </button>
                     </div>
-                </div>
-                
-                <!-- Mobile Menu -->
-                <div class="mobile-menu md:hidden fixed inset-0 bg-white z-40 pt-20 px-6">
-                            <button class="absolute top-4 right-4 p-2" id="mobile-menu-close">
-                                <i data-feather="x" class="w-6 h-6 text-gray-700"></button>
-                            
-                            <div class="space-y-6">
-                                <a href="index.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Home
-                            </a>
-                            <a href="dashboard.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Dashboard
-                            </a>
-                            <a href="editor.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Editor
-                            </a>
-                            <a href="templates.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Editor
-                            </a>
-                            <a href="templates.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Templates
-                            </a>
-                            <a href="pricing.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Templates
-                            </a>
-                            <a href="pricing.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Pricing
-                            </a>
-                            <a href="integrations.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Integrations
-                            </a>
-                            <a href="help.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Help
-                            </a>
-<div class="pt-6 border-t border-gray-200">
-                                <a href="login.html" class="block text-lg font-medium text-gray-700 hover:text-purple-600 transition-colors duration-300">
-                                Sign In
-                            </a>
-                            <a href="dashboard.html" class="block mt-4 bg-purple-600 text-white text-lg font-medium px-4 py-2 rounded-lg text-center">
-                                Get Started
-                            </a>
-                        </div>
-</div>
+                    <div class="mobile-divider"></div>
+                    <div class="mobile-links">
+                        ${mobileLinks}
+                    </div>
+                    <div class="mobile-divider"></div>
+                    <div class="mobile-auth">
+                        <a href="${AUTH_ACTIONS[0].href}" class="nav-link mobile-link" data-auth>${AUTH_ACTIONS[0].label}</a>
+                        <a href="${AUTH_ACTIONS[1].href}" class="mobile-cta" data-auth>${AUTH_ACTIONS[1].label}</a>
+                    </div>
                 </div>
             </nav>
         `;
-        
-        // Add scroll effect
+
         this.addScrollEffect();
-        
-        // Initialize mobile menu
         this.initMobileMenu();
-        
-        // Initialize Feather icons after a short delay
+        this.highlightActiveLink();
+        this.initFeatherIcons();
+
+        window.addEventListener('popstate', this.handleRouteChange);
+        window.addEventListener('hashchange', this.handleRouteChange);
+    }
+
+    initFeatherIcons() {
         setTimeout(() => {
             if (typeof feather !== 'undefined') {
-                feather.replace();
+                feather.replace({
+                    class: 'feather-icon'
+                });
             }
-        }, 100);
+        }, 120);
     }
+
     addScrollEffect() {
         const navbar = this.shadowRoot.querySelector('.navbar');
         window.addEventListener('scroll', () => {
@@ -168,26 +449,70 @@ class CustomNavbar extends HTMLElement {
             }
         });
     }
-initMobileMenu() {
+
+    initMobileMenu() {
         const menuButton = this.shadowRoot.getElementById('mobile-menu-button');
         const menuClose = this.shadowRoot.getElementById('mobile-menu-close');
         const mobileMenu = this.shadowRoot.querySelector('.mobile-menu');
-        
-        menuButton.addEventListener('click', () => {
-            mobileMenu.classList.add('open');
-        });
-        
-        menuClose.addEventListener('click', () => {
-            mobileMenu.classList.remove('open');
-        });
-        
-        // Close menu when clicking on links
+        const scrim = this.shadowRoot.querySelector('.mobile-scrim');
+
+        if (!menuButton || !menuClose || !mobileMenu || !scrim) {
+            return;
+        }
+
+        const toggleMenu = (open) => {
+            mobileMenu.classList.toggle('open', open);
+            menuButton.setAttribute('aria-expanded', String(open));
+            if (scrim) {
+                scrim.classList.toggle('visible', open);
+                scrim.hidden = !open;
+            }
+            if (open) {
+                mobileMenu.focus();
+            }
+        };
+
+        menuButton.addEventListener('click', () => toggleMenu(true));
+        menuClose.addEventListener('click', () => toggleMenu(false));
+        scrim.addEventListener('click', () => toggleMenu(false));
+
+        this.handleCloseOnEscape = (event) => {
+            if (event.key === 'Escape' && mobileMenu.classList.contains('open')) {
+                toggleMenu(false);
+            }
+        };
+
+        window.addEventListener('keydown', this.handleCloseOnEscape);
+
         const mobileLinks = mobileMenu.querySelectorAll('a');
-        mobileLinks.forEach(link => {
-            link.addEventListener('click', () => {
-                mobileMenu.classList.remove('open');
-            });
+        mobileLinks.forEach((link) => {
+            link.addEventListener('click', () => toggleMenu(false));
         });
+    }
+
+    highlightActiveLink() {
+        const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+        const normalize = (href) => href.replace('./', '');
+
+        this.shadowRoot.querySelectorAll('[data-nav]').forEach((link) => {
+            const href = normalize(link.getAttribute('href') || '');
+            const isActive = href === currentPath || (href === 'index.html' && currentPath === '');
+            if (isActive) {
+                link.classList.add('is-active');
+                link.setAttribute('aria-current', 'page');
+            } else {
+                link.classList.remove('is-active');
+                link.removeAttribute('aria-current');
+            }
+        });
+    }
+
+    disconnectedCallback() {
+        window.removeEventListener('popstate', this.handleRouteChange);
+        window.removeEventListener('hashchange', this.handleRouteChange);
+        if (this.handleCloseOnEscape) {
+            window.removeEventListener('keydown', this.handleCloseOnEscape);
+        }
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -3,13 +3,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 :root {
-    --color-primary: #7c3aed;
-    --color-primary-dark: #4f46e5;
-    --color-accent: #f97316;
-    --color-surface: #ffffff;
-    --color-muted: #64748b;
-    --shadow-soft: 0 20px 45px rgba(67, 56, 202, 0.12);
-    --shadow-strong: 0 30px 65px rgba(76, 29, 149, 0.2);
+    --color-primary: #38bdf8;
+    --color-primary-dark: #0ea5e9;
+    --color-accent: #22d3ee;
+    --color-surface: rgba(8, 19, 51, 0.72);
+    --color-muted: #94a3b8;
+    --shadow-soft: 0 18px 38px rgba(9, 132, 227, 0.18);
+    --shadow-strong: 0 35px 70px rgba(14, 30, 64, 0.55);
 }
 
 * {
@@ -21,10 +21,63 @@
 body {
     font-family: 'Inter', sans-serif;
     line-height: 1.6;
-    background: radial-gradient(circle at top right, rgba(124, 58, 237, 0.08), transparent 45%),
-        radial-gradient(circle at bottom left, rgba(14, 116, 144, 0.08), transparent 40%),
-        #f8fafc;
-    color: #0f172a;
+    background:
+        radial-gradient(circle at 15% 20%, rgba(56, 189, 248, 0.18), transparent 45%),
+        radial-gradient(circle at 85% 10%, rgba(34, 211, 238, 0.12), transparent 40%),
+        radial-gradient(circle at 50% 100%, rgba(8, 19, 51, 0.95), rgba(2, 6, 23, 0.95));
+    color: #e2e8f0;
+    color-scheme: dark;
+}
+
+body[class*='bg-gradient-to-'] {
+    background:
+        radial-gradient(circle at 15% 20%, rgba(56, 189, 248, 0.18), transparent 45%),
+        radial-gradient(circle at 85% 10%, rgba(34, 211, 238, 0.12), transparent 40%),
+        radial-gradient(circle at 50% 100%, rgba(8, 19, 51, 0.95), rgba(2, 6, 23, 0.95)) !important;
+}
+
+/* Dark theme overrides for Tailwind utility classes */
+.text-gray-800,
+.text-slate-800,
+.text-slate-700,
+.text-slate-600,
+.text-gray-700,
+.text-gray-600 {
+    color: rgba(226, 232, 240, 0.92);
+}
+
+.text-gray-500,
+.text-slate-500 {
+    color: rgba(203, 213, 225, 0.78);
+}
+
+.text-gray-400,
+.text-slate-400 {
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.bg-white,
+.bg-slate-50,
+.bg-slate-100,
+.bg-gray-50 {
+    background: rgba(6, 18, 43, 0.78) !important;
+    color: #e2e8f0;
+    border: 1px solid rgba(56, 189, 248, 0.12);
+}
+
+.bg-gradient-to-r.from-purple-600.to-indigo-600,
+.bg-gradient-to-br.from-purple-600.to-indigo-600,
+.bg-gradient-to-r.from-purple-500.to-indigo-600,
+.bg-gradient-to-br.from-pink-500.to-purple-600 {
+    background-image: linear-gradient(120deg, rgba(14, 42, 91, 0.95), rgba(2, 132, 199, 0.95)) !important;
+    border: 1px solid rgba(56, 189, 248, 0.24);
+    box-shadow: 0 25px 50px rgba(2, 12, 31, 0.6);
+}
+
+.shadow-xl,
+.shadow-lg,
+.shadow-advanced {
+    box-shadow: 0 24px 48px rgba(2, 12, 31, 0.6) !important;
 }
 
 /* Smooth scrolling */
@@ -38,16 +91,16 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-    background: #f1f1f1;
+    background: rgba(15, 23, 42, 0.7);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(8, 145, 178, 0.9));
     border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(135deg, #764ba2, #667eea);
+    background: linear-gradient(135deg, rgba(14, 165, 233, 1), rgba(3, 105, 161, 1));
 }
 /* Enhanced Animation classes */
 .fade-in {
@@ -87,29 +140,33 @@ html {
 }
 
 .navbar {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    background: linear-gradient(135deg, rgba(7, 17, 35, 0.92), rgba(3, 9, 26, 0.88));
+    backdrop-filter: blur(24px) saturate(180%);
+    border-bottom: 1px solid rgba(56, 189, 248, 0.18);
     transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 
-        0 8px 32px rgba(0, 0, 0, 0.08);
+    box-shadow:
+        0 16px 40px rgba(2, 8, 23, 0.6),
+        inset 0 1px 0 rgba(148, 163, 184, 0.05);
 }
 
 .navbar-scrolled {
-    background: rgba(255, 255, 255, 0.98);
-    backdrop-filter: blur(25px);
-    box-shadow: 
-        0 12px 40px rgba(0, 0, 0, 0.1),
-        inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    background: linear-gradient(135deg, rgba(4, 12, 31, 0.95), rgba(2, 6, 20, 0.95));
+    border-bottom-color: rgba(56, 189, 248, 0.28);
+    box-shadow:
+        0 20px 60px rgba(2, 8, 23, 0.7),
+        inset 0 1px 0 rgba(148, 163, 184, 0.08);
 }
 
 .nav-link {
     position: relative;
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    color: #cbd5f5;
+    letter-spacing: 0.01em;
+    transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.nav-link:hover {
-    color: #7c3aed;
+.nav-link:hover,
+.nav-link:focus-visible {
+    color: #ffffff;
     transform: translateY(-2px);
 }
 
@@ -118,34 +175,47 @@ html {
     position: absolute;
     width: 0;
     height: 2px;
-    bottom: -4px;
+    bottom: -6px;
     left: 0;
-    background: linear-gradient(135deg, #7c3aed, #4f46e5);
-    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    background: linear-gradient(120deg, var(--color-primary), var(--color-accent));
+    box-shadow: 0 0 12px rgba(34, 211, 238, 0.6);
+    transition: width 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.nav-link:hover::after {
+.nav-link[aria-current='page']::after,
+.nav-link:hover::after,
+.nav-link:focus-visible::after {
     width: 100%;
+}
+
+.nav-link[aria-current='page'] {
+    color: #ffffff;
+    text-shadow: 0 0 12px rgba(56, 189, 248, 0.45);
 }
 
 .mobile-menu {
     transform: translateX(-100%);
     transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    background: linear-gradient(145deg, rgba(5, 16, 42, 0.96), rgba(3, 10, 28, 0.92));
+    backdrop-filter: blur(30px) saturate(160%);
 }
 
 .mobile-menu.open {
     transform: translateX(0);
 }
 
-/* Enhanced mobile menu with glass effect */
-.mobile-menu {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(25px);
+.mobile-menu a {
+    color: #cbd5f5;
+}
+
+.mobile-menu a:hover,
+.mobile-menu a:focus-visible {
+    color: #ffffff;
 }
 /* Enhanced Loading spinner */
 .loading-spinner {
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    border-top: 2px solid #8b5cf6;
+    border: 2px solid rgba(148, 163, 184, 0.25);
+    border-top: 2px solid var(--color-primary);
     border-radius: 50%;
     width: 24px;
     height: 24px;
@@ -159,18 +229,18 @@ html {
 
 /* Advanced Glass morphism effects */
 .glass {
-    background: rgba(255, 255, 255, 0.15);
-    backdrop-filter: blur(20px) saturate(180%);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    box-shadow: 
-        0 8px 32px rgba(0, 0, 0, 0.1),
-        inset 0 1px 0 rgba(255, 255, 255, 0.2);
+    background: rgba(9, 22, 52, 0.68);
+    backdrop-filter: blur(26px) saturate(190%);
+    border: 1px solid rgba(56, 189, 248, 0.15);
+    box-shadow:
+        0 25px 45px rgba(2, 12, 31, 0.55),
+        inset 0 1px 0 rgba(148, 163, 184, 0.08);
 }
 
 .glass-dark {
-    background: rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(1, 9, 26, 0.72);
+    backdrop-filter: blur(20px) saturate(200%);
+    border: 1px solid rgba(15, 118, 110, 0.25);
 }
 
 /* Enhanced Gradient text animation */
@@ -196,7 +266,7 @@ html {
 
 /* Advanced Custom button hover effects */
 .btn-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(120deg, rgba(59, 130, 246, 0.95) 0%, rgba(2, 132, 199, 0.95) 40%, rgba(56, 189, 248, 0.95) 100%);
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
     overflow: hidden;
@@ -219,9 +289,9 @@ html {
 
 .btn-primary:hover {
     transform: translateY(-3px);
-    box-shadow: 
-        0 15px 30px rgba(102, 126, 234, 0.4),
-        0 0 20px rgba(118, 75, 162, 0.3);
+    box-shadow:
+        0 18px 38px rgba(34, 211, 238, 0.35),
+        0 0 24px rgba(56, 189, 248, 0.45);
 }
 
 /* Advanced Card hover effects with glass morphism */
@@ -241,8 +311,9 @@ html {
     position: relative;
     border-radius: 32px;
     padding: clamp(2.5rem, 5vw, 4rem);
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.9));
-    box-shadow: var(--shadow-soft);
+    background: linear-gradient(160deg, rgba(9, 19, 48, 0.92), rgba(3, 8, 24, 0.88));
+    box-shadow: var(--shadow-strong);
+    border: 1px solid rgba(56, 189, 248, 0.14);
 }
 
 .hero-section::before {
@@ -250,7 +321,7 @@ html {
     position: absolute;
     inset: 12px;
     border-radius: inherit;
-    border: 1px solid rgba(255, 255, 255, 0.35);
+    border: 1px solid rgba(56, 189, 248, 0.18);
     pointer-events: none;
 }
 
@@ -260,10 +331,11 @@ html {
     gap: 0.5rem;
     padding: 0.4rem 0.9rem;
     border-radius: 999px;
-    background: rgba(124, 58, 237, 0.12);
+    background: rgba(56, 189, 248, 0.16);
     color: var(--color-primary);
     font-weight: 600;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 .hero-badge svg {
@@ -276,30 +348,33 @@ html {
     flex-direction: column;
     padding: 1rem 1.5rem;
     border-radius: 20px;
-    background: rgba(255, 255, 255, 0.85);
-    box-shadow: var(--shadow-soft);
+    background: rgba(6, 18, 43, 0.8);
+    box-shadow: 0 20px 40px rgba(2, 8, 23, 0.45);
     min-width: 160px;
+    border: 1px solid rgba(56, 189, 248, 0.12);
 }
 
 .hero-metric strong {
     font-size: 1.75rem;
     line-height: 1.1;
     color: var(--color-primary);
+    text-shadow: 0 0 16px rgba(34, 211, 238, 0.35);
 }
 
 .hero-metric span {
-    color: var(--color-muted);
+    color: rgba(203, 213, 225, 0.8);
     font-size: 0.9rem;
 }
 
 .hero-visual {
     position: relative;
     border-radius: 28px;
-    background: linear-gradient(160deg, rgba(124, 58, 237, 0.9), rgba(14, 165, 233, 0.85));
+    background: linear-gradient(155deg, rgba(14, 42, 91, 0.95), rgba(2, 11, 32, 0.9));
     padding: clamp(1.5rem, 3vw, 2.5rem);
     color: #ffffff;
     box-shadow: var(--shadow-strong);
     overflow: hidden;
+    border: 1px solid rgba(34, 211, 238, 0.18);
 }
 
 .hero-visual::after {
@@ -307,17 +382,18 @@ html {
     position: absolute;
     inset: 18px;
     border-radius: 24px;
-    border: 1px solid rgba(255, 255, 255, 0.25);
+    border: 1px solid rgba(56, 189, 248, 0.15);
     pointer-events: none;
 }
 
 .hero-visual .floating-card {
     position: relative;
-    background: rgba(255, 255, 255, 0.12);
+    background: rgba(8, 24, 61, 0.75);
     border-radius: 18px;
     padding: 1.25rem;
-    backdrop-filter: blur(18px);
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+    backdrop-filter: blur(22px) saturate(160%);
+    box-shadow: 0 24px 48px rgba(2, 12, 31, 0.55);
+    border: 1px solid rgba(34, 211, 238, 0.18);
 }
 
 .hero-visual .floating-card + .floating-card {
@@ -333,7 +409,7 @@ html {
     width: 100%;
     height: 10px;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.25);
+    background: rgba(15, 118, 110, 0.25);
     margin-top: 0.75rem;
     overflow: hidden;
 }
@@ -342,8 +418,8 @@ html {
     display: block;
     height: 100%;
     border-radius: inherit;
-    background: linear-gradient(135deg, #facc15, #f97316);
-    box-shadow: 0 8px 20px rgba(249, 115, 22, 0.3);
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.9), rgba(20, 184, 166, 0.9));
+    box-shadow: 0 8px 20px rgba(56, 189, 248, 0.3);
 }
 
 .avatar-stack {
@@ -358,11 +434,11 @@ html {
     width: 40px;
     height: 40px;
     border-radius: 999px;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(226, 232, 240, 0.9));
-    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
-    color: var(--color-primary);
+    background: linear-gradient(140deg, rgba(8, 47, 73, 0.92), rgba(2, 132, 199, 0.92));
+    box-shadow: 0 12px 24px rgba(2, 12, 31, 0.4);
+    color: #e0f2fe;
     font-weight: 600;
-    border: 2px solid #ffffff;
+    border: 1px solid rgba(34, 211, 238, 0.3);
 }
 
 .avatar-stack span + span {
@@ -371,7 +447,7 @@ html {
 
 .avatar-stack small {
     margin-left: 1rem;
-    color: var(--color-muted);
+    color: rgba(203, 213, 225, 0.75);
     font-weight: 500;
 }
 
@@ -381,11 +457,12 @@ html {
     gap: 0.4rem;
     padding: 0.3rem 0.75rem;
     border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: var(--color-primary-dark);
+    background: rgba(56, 189, 248, 0.14);
+    color: #e0f2fe;
     font-size: 0.8rem;
     font-weight: 600;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .feature-chip svg {
@@ -403,19 +480,24 @@ html {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1.25rem;
+    padding: 1.5rem;
     border-radius: 18px;
-    background: rgba(255, 255, 255, 0.8);
-    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-    color: #1e293b;
+    background: rgba(8, 21, 46, 0.78);
+    box-shadow: 0 18px 38px rgba(2, 12, 31, 0.45);
+    color: #e2e8f0;
     font-weight: 600;
+    border: 1px solid rgba(56, 189, 248, 0.18);
 }
 
 .logo-tile span {
     display: inline-block;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    font-size: 0.8rem;
+    font-size: 0.85rem;
+    background: linear-gradient(130deg, rgba(94, 234, 212, 0.9), rgba(56, 189, 248, 0.9));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    text-shadow: 0 0 16px rgba(56, 189, 248, 0.35);
 }
 
 .timeline {
@@ -430,16 +512,18 @@ html {
     top: 0;
     bottom: 0;
     width: 2px;
-    background: linear-gradient(180deg, rgba(76, 29, 149, 0.2), rgba(14, 116, 144, 0.1));
+    background: linear-gradient(180deg, rgba(34, 211, 238, 0.45), rgba(14, 165, 233, 0));
+    box-shadow: 0 0 18px rgba(34, 211, 238, 0.3);
 }
 
 .timeline-step {
     position: relative;
     padding: 1.25rem 1.25rem 1.25rem 1.5rem;
     border-radius: 18px;
-    background: rgba(255, 255, 255, 0.9);
-    box-shadow: 0 10px 35px rgba(15, 23, 42, 0.08);
+    background: rgba(6, 18, 43, 0.78);
+    box-shadow: 0 16px 32px rgba(2, 12, 31, 0.45);
     margin-bottom: 1.5rem;
+    border: 1px solid rgba(56, 189, 248, 0.12);
 }
 
 .timeline-step::before {
@@ -448,20 +532,22 @@ html {
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-    border: 3px solid #ffffff;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 1), rgba(20, 184, 166, 1));
+    border: 3px solid rgba(15, 23, 42, 0.85);
     left: -2.2rem;
     top: 1.75rem;
-    box-shadow: 0 6px 12px rgba(124, 58, 237, 0.35);
+    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.25), 0 10px 18px rgba(8, 145, 178, 0.4);
 }
 
 .cta-banner {
     position: relative;
     border-radius: 28px;
     padding: clamp(2.5rem, 5vw, 3.5rem);
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 116, 144, 0.9));
+    background: linear-gradient(140deg, rgba(7, 17, 35, 0.95), rgba(12, 74, 110, 0.85));
     color: #ffffff;
     overflow: hidden;
+    border: 1px solid rgba(56, 189, 248, 0.18);
+    box-shadow: var(--shadow-strong);
 }
 
 .cta-banner::after {
@@ -469,7 +555,7 @@ html {
     position: absolute;
     inset: 18px;
     border-radius: 24px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(56, 189, 248, 0.12);
 }
 
 .cta-banner h2 {
@@ -488,7 +574,7 @@ html {
 }
 
 .feature-subcopy {
-    color: var(--color-muted);
+    color: rgba(203, 213, 225, 0.78);
     font-size: 0.95rem;
 }
 
@@ -545,13 +631,13 @@ html {
 
 @keyframes glow {
     from {
-        box-shadow: 
-            0 0 20px rgba(102, 126, 234, 0.3);
+        box-shadow:
+            0 0 20px rgba(56, 189, 248, 0.25);
     }
     to {
-        box-shadow: 
-            0 0 30px rgba(102, 126, 234, 0.5),
-            0 0 60px rgba(118, 75, 162, 0.3);
+        box-shadow:
+            0 0 30px rgba(56, 189, 248, 0.45),
+            0 0 60px rgba(20, 184, 166, 0.3);
     }
 }
 
@@ -563,15 +649,15 @@ html {
 @keyframes pulse {
     0% {
         transform: scale(1);
-        box-shadow: 0 0 0 0 rgba(102, 126, 234, 0.7);
+        box-shadow: 0 0 0 0 rgba(56, 189, 248, 0.6);
     }
     70% {
         transform: scale(1);
-        box-shadow: 0 0 0 0 rgba(102, 126, 234, 0.7);
+        box-shadow: 0 0 0 0 rgba(56, 189, 248, 0.6);
     }
     100% {
         transform: scale(1);
-        box-shadow: 0 0 0 10px rgba(102, 126, 234, 0);
+        box-shadow: 0 0 0 10px rgba(56, 189, 248, 0);
     }
 }
 
@@ -595,27 +681,27 @@ html {
 }
 
 .morph-bg::before {
-    background: radial-gradient(circle, rgba(124, 58, 237, 0.35), rgba(30, 64, 175, 0));
+    background: radial-gradient(circle, rgba(56, 189, 248, 0.42), rgba(30, 64, 175, 0));
     top: -140px;
     right: -120px;
 }
 
 .morph-bg::after {
-    background: radial-gradient(circle, rgba(236, 72, 153, 0.25), rgba(240, 171, 0, 0));
+    background: radial-gradient(circle, rgba(20, 184, 166, 0.35), rgba(12, 74, 110, 0));
     bottom: -160px;
     left: -120px;
 }
 
 /* Enhanced shadow effects */
 .shadow-advanced {
-    box-shadow: 
-        0 10px 25px rgba(0, 0, 0, 0.08);
+    box-shadow:
+        0 20px 45px rgba(2, 12, 31, 0.55);
 }
 
 .shadow-advanced:hover {
-    box-shadow: 
-        0 25px 50px rgba(0, 0, 0, 0.12),
-        0 0 0 1px rgba(255, 255, 255, 0.1);
+    box-shadow:
+        0 28px 60px rgba(2, 12, 31, 0.65),
+        0 0 0 1px rgba(56, 189, 248, 0.16);
 }
 
 /* Advanced text effects */


### PR DESCRIPTION
## Summary
- restyle the global surface colors, gradients, and glassmorphism to deliver a dark neon presentation
- refresh the custom navbar component with sleeker desktop links, improved mobile drawer, and route highlighting
- align utility overrides and component chrome (cards, hero, timeline, CTA) with the new palette and glow accents

## Testing
- Not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691799fd71dc8333994a0485f672566d)